### PR TITLE
vulkan: use private VRAM for GPU scratch

### DIFF
--- a/q36.c
+++ b/q36.c
@@ -4523,6 +4523,12 @@ static q36_vulkan_runtime *q36_vulkan_runtime_create(int ctx_size,
         rt->field = q36_gpu_tensor_alloc((uint64_t)(n) * prefill_cap * sizeof(float)); \
         if (!rt->field) goto fail; \
     } while (0)
+#define Q36_GPU_ALLOC_SCRATCH_F32(field, n) do { \
+        rt->field = quality ? \
+            q36_gpu_tensor_alloc((uint64_t)(n) * prefill_cap * sizeof(float)) : \
+            q36_gpu_tensor_alloc_scratch((uint64_t)(n) * prefill_cap * sizeof(float)); \
+        if (!rt->field) goto fail; \
+    } while (0)
 #define Q36_GPU_ALLOC_U32(field, n) do { \
         rt->field = q36_gpu_tensor_alloc((uint64_t)(n) * prefill_cap * sizeof(uint32_t)); \
         if (!rt->field) goto fail; \
@@ -4535,16 +4541,18 @@ static q36_vulkan_runtime *q36_vulkan_runtime_create(int ctx_size,
     Q36_GPU_ALLOC_F32(next_hidden, Q36_N_EMBD);
     Q36_GPU_ALLOC_F32(embed_stage[0], Q36_N_EMBD);
     Q36_GPU_ALLOC_F32(embed_stage[1], Q36_N_EMBD);
-    Q36_GPU_ALLOC_F32(norm, Q36_N_EMBD);
+    Q36_GPU_ALLOC_SCRATCH_F32(norm, Q36_N_EMBD);
     rt->last_h = q36_gpu_tensor_alloc((uint64_t)Q36_N_EMBD * sizeof(float));
     if (!rt->last_h) goto fail;
-    rt->inp_q8 = q36_gpu_tensor_alloc((uint64_t)((Q36_N_EMBD + Q36_QK_K - 1u) / Q36_QK_K) * Q36_VK_Q8_K_BYTES * prefill_cap);
+    rt->inp_q8 = quality ?
+        q36_gpu_tensor_alloc((uint64_t)((Q36_N_EMBD + Q36_QK_K - 1u) / Q36_QK_K) * Q36_VK_Q8_K_BYTES * prefill_cap) :
+        q36_gpu_tensor_alloc_scratch((uint64_t)((Q36_N_EMBD + Q36_QK_K - 1u) / Q36_QK_K) * Q36_VK_Q8_K_BYTES * prefill_cap);
     if (!rt->inp_q8) goto fail;
-    Q36_GPU_ALLOC_F32(attn_qg, Q36_N_HEAD * Q36_N_HEAD_DIM * 2u);
-    Q36_GPU_ALLOC_F32(attn_q, Q36_N_HEAD * Q36_N_HEAD_DIM);
-    Q36_GPU_ALLOC_F32(attn_k, Q36_N_HEAD_KV * Q36_N_HEAD_DIM);
-    Q36_GPU_ALLOC_F32(attn_v, Q36_N_HEAD_KV * Q36_N_VALUE_DIM);
-    Q36_GPU_ALLOC_F32(attn_out, Q36_N_SSM_INNER);
+    Q36_GPU_ALLOC_SCRATCH_F32(attn_qg, Q36_N_HEAD * Q36_N_HEAD_DIM * 2u);
+    Q36_GPU_ALLOC_SCRATCH_F32(attn_q, Q36_N_HEAD * Q36_N_HEAD_DIM);
+    Q36_GPU_ALLOC_SCRATCH_F32(attn_k, Q36_N_HEAD_KV * Q36_N_HEAD_DIM);
+    Q36_GPU_ALLOC_SCRATCH_F32(attn_v, Q36_N_HEAD_KV * Q36_N_VALUE_DIM);
+    Q36_GPU_ALLOC_SCRATCH_F32(attn_out, Q36_N_SSM_INNER);
     /* A layer is attention or recurrent, never both. These equal-sized
      * views remove 64 MiB of mutually exclusive 1024-row scratch. */
     rt->recur_qkv = q36_gpu_tensor_view(rt->attn_qg, 0,
@@ -4568,15 +4576,15 @@ static q36_vulkan_runtime *q36_vulkan_runtime_create(int ctx_size,
     Q36_GPU_ALLOC_F32(ffn_gate_logits, Q36_N_EXPERT);
     Q36_GPU_ALLOC_U32(ffn_selected, Q36_N_EXPERT_USED);
     Q36_GPU_ALLOC_F32(ffn_weights, Q36_N_EXPERT_USED);
-    Q36_GPU_ALLOC_F32(ffn_shared_gate, Q36_N_FF_SHARED);
-    Q36_GPU_ALLOC_F32(ffn_shared_up, Q36_N_FF_SHARED);
-    Q36_GPU_ALLOC_F32(ffn_shared_mid, Q36_N_FF_SHARED);
-    Q36_GPU_ALLOC_F32(ffn_shared_out, Q36_N_EMBD);
-    Q36_GPU_ALLOC_F32(ffn_scalar, 1);
+    Q36_GPU_ALLOC_SCRATCH_F32(ffn_shared_gate, Q36_N_FF_SHARED);
+    Q36_GPU_ALLOC_SCRATCH_F32(ffn_shared_up, Q36_N_FF_SHARED);
+    Q36_GPU_ALLOC_SCRATCH_F32(ffn_shared_mid, Q36_N_FF_SHARED);
+    Q36_GPU_ALLOC_SCRATCH_F32(ffn_shared_out, Q36_N_EMBD);
+    Q36_GPU_ALLOC_SCRATCH_F32(ffn_scalar, 1);
     /* The fused attention path never touches the scores scratch; skipping it
      * saves ctx_size * n_head * prefill_cap floats (128 MiB at ctx 32k). */
     if (!q36_gpu_attn_fused_enabled())
-        Q36_GPU_ALLOC_F32(scores, (uint64_t)ctx_size * Q36_N_HEAD);
+        Q36_GPU_ALLOC_SCRATCH_F32(scores, (uint64_t)ctx_size * Q36_N_HEAD);
     rt->logits = q36_gpu_tensor_alloc((uint64_t)Q36_N_VOCAB * sizeof(float));
     if (!rt->logits) goto fail;
     if (enable_mtp) {
@@ -4622,11 +4630,13 @@ static q36_vulkan_runtime *q36_vulkan_runtime_create(int ctx_size,
     }
     if (!q36_vulkan_runtime_reset(rt)) goto fail;
 #undef Q36_GPU_ALLOC_F32
+#undef Q36_GPU_ALLOC_SCRATCH_F32
 #undef Q36_GPU_ALLOC_U32
 #undef Q36_GPU_ALLOC_MTP_F32
     return rt;
 fail:
 #undef Q36_GPU_ALLOC_F32
+#undef Q36_GPU_ALLOC_SCRATCH_F32
 #undef Q36_GPU_ALLOC_U32
 #undef Q36_GPU_ALLOC_MTP_F32
     q36_vulkan_runtime_free(rt);

--- a/q36_gpu.h
+++ b/q36_gpu.h
@@ -28,6 +28,8 @@ void q36_gpu_parallel_for_rows(uint64_t n_rows,
                                void *ctx);
 
 q36_gpu_tensor *q36_gpu_tensor_alloc(uint64_t bytes);
+/* Output-only scratch. Contents are undefined until a GPU command writes it. */
+q36_gpu_tensor *q36_gpu_tensor_alloc_scratch(uint64_t bytes);
 q36_gpu_tensor *q36_gpu_tensor_view(const q36_gpu_tensor *base, uint64_t offset, uint64_t bytes);
 void q36_gpu_tensor_free(q36_gpu_tensor *tensor);
 uint64_t q36_gpu_tensor_bytes(const q36_gpu_tensor *tensor);

--- a/q36_vulkan.c
+++ b/q36_vulkan.c
@@ -37,9 +37,11 @@ typedef struct q36_gpu_tensor {
     unsigned char *data;
     uint64_t bytes;
     uint64_t alloc_bytes;
+    uint64_t private_charge;
     uint64_t offset;
     struct q36_gpu_tensor *owner;
     bool device_local;
+    bool private_scratch;
     bool weight_only;           /* arena-backed weights: uploaded once, never
                                  * written by dispatches, skipped by the
                                  * batch hazard tracker */
@@ -335,17 +337,21 @@ typedef struct {
 
 static q36_vk_stream_cache q36_vk_stream;
 
-/* Free-list of retired scratch tensors.  Decode allocates the same handful
- * of small buffers every layer (q8 activations, expert mids, attention aux);
- * reusing them skips a vkAllocateMemory/vkFreeMemory round-trip per buffer.
- * Reused tensors are re-zeroed so semantics match a fresh allocation. */
+/* Decode allocates the same output-only buffers every layer. Reusing them
+ * avoids a vkAllocateMemory/vkFreeMemory round-trip without CPU mapping. */
 enum {
     Q36_VK_POOL_CAP = 256,
     Q36_VK_POOL_MAX_BYTES = 1u << 20,
+    Q36_VK_PRIVATE_POOL_CAP = 64,
+    Q36_VK_PRIVATE_LIMIT = 512u << 20,
     Q36_VK_MAX_THREADS = 32,
 };
 static q36_gpu_tensor *q36_vk_pool[Q36_VK_POOL_CAP];
 static uint32_t q36_vk_pool_n;
+static q36_gpu_tensor *q36_vk_private_pool[Q36_VK_PRIVATE_POOL_CAP];
+static uint32_t q36_vk_private_pool_n;
+static uint64_t q36_vk_private_bytes;
+static uint64_t q36_vk_private_peak;
 
 typedef struct {
     pthread_mutex_t mu;
@@ -1216,6 +1222,17 @@ static uint32_t q36_vk_find_memory_type(uint32_t bits, VkMemoryPropertyFlags wan
     return UINT32_MAX;
 }
 
+static uint32_t q36_vk_find_memory_type_avoiding(uint32_t bits,
+                                                 VkMemoryPropertyFlags want,
+                                                 VkMemoryPropertyFlags avoid) {
+    for (uint32_t i = 0; i < q36_vk.mem_props.memoryTypeCount; i++) {
+        if ((bits & (1u << i)) == 0) continue;
+        VkMemoryPropertyFlags flags = q36_vk.mem_props.memoryTypes[i].propertyFlags;
+        if ((flags & want) == want && (flags & avoid) == 0) return i;
+    }
+    return UINT32_MAX;
+}
+
 static void q36_vk_kernel_destroy(q36_vk_kernel *k) {
     if (!q36_vk.device || !k) return;
     if (k->pipeline) vkDestroyPipeline(q36_vk.device, k->pipeline, NULL);
@@ -1342,12 +1359,7 @@ static int q36_vk_kernel_init(q36_vk_kernel *k) {
     return 1;
 }
 
-/* Allocate from DEVICE_LOCAL-only memory (the VRAM carve-out / BAR
- * aperture, types 0/1/7 in heap 1 on the BC-250).  The tensor is NOT
- * host-mapped; writes must go through q36_vk_write_tensor_staged().
- * Returns NULL on OOM or if no DEVICE_LOCAL-only type supports the
- * buffer's required memory type bits. */
-static q36_gpu_tensor *q36_vk_tensor_alloc_dl_only_unlocked(uint64_t bytes) {
+static q36_gpu_tensor *q36_vk_tensor_alloc_dl_unlocked(uint64_t bytes) {
     q36_gpu_tensor *tensor = calloc(1, sizeof(*tensor));
     if (!tensor) return NULL;
     tensor->bytes = bytes;
@@ -1356,7 +1368,9 @@ static q36_gpu_tensor *q36_vk_tensor_alloc_dl_only_unlocked(uint64_t bytes) {
     VkBufferCreateInfo bci = {
         .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
         .size = tensor->alloc_bytes,
-        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                 VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                 VK_BUFFER_USAGE_TRANSFER_DST_BIT,
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
     if (vkCreateBuffer(q36_vk.device, &bci, NULL, &tensor->buffer) != VK_SUCCESS) {
@@ -1366,13 +1380,17 @@ static q36_gpu_tensor *q36_vk_tensor_alloc_dl_only_unlocked(uint64_t bytes) {
 
     VkMemoryRequirements req;
     vkGetBufferMemoryRequirements(q36_vk.device, tensor->buffer, &req);
-    uint32_t mt = q36_vk_find_memory_type(req.memoryTypeBits,
-                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    tensor->private_charge = req.size;
+    uint32_t mt = q36_vk_find_memory_type_avoiding(
+            req.memoryTypeBits,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (mt == UINT32_MAX) {
         vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
         free(tensor);
         return NULL;
     }
+
     VkMemoryAllocateInfo mai = {
         .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
         .allocationSize = req.size,
@@ -1389,110 +1407,11 @@ static q36_gpu_tensor *q36_vk_tensor_alloc_dl_only_unlocked(uint64_t bytes) {
         free(tensor);
         return NULL;
     }
+
     tensor->device_local = true;
+    q36_gpu_live_bytes += bytes;
+    if (q36_gpu_live_bytes > q36_gpu_peak_bytes) q36_gpu_peak_bytes = q36_gpu_live_bytes;
     return tensor;
-}
-
-/* Staging copy helper for DEVICE_LOCAL-only tensors.  Creates a temporary
- * host-visible staging buffer, copies |bytes| from |src| into it, records a
- * vkCmdCopyBuffer from staging to the root buffer at |dst_offset|, submits
- * on its own command buffer (independent of the main batch), and waits for
- * completion.  Only suitable for one-shot uploads at init time. */
-static int q36_vk_write_tensor_staged(q36_gpu_tensor *tensor, uint64_t dst_offset,
-                                       const void *src, uint64_t bytes) {
-    VkBufferCreateInfo bci = {
-        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-        .size = bytes,
-        .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
-    };
-    VkBuffer staging;
-    if (vkCreateBuffer(q36_vk.device, &bci, NULL, &staging) != VK_SUCCESS) return 0;
-
-    VkMemoryRequirements req;
-    vkGetBufferMemoryRequirements(q36_vk.device, staging, &req);
-    uint32_t mt = q36_vk_find_memory_type(req.memoryTypeBits,
-                                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    if (mt == UINT32_MAX) {
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    VkDeviceMemory staging_mem;
-    VkMemoryAllocateInfo mai = {
-        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-        .allocationSize = req.size,
-        .memoryTypeIndex = mt,
-    };
-    if (vkAllocateMemory(q36_vk.device, &mai, NULL, &staging_mem) != VK_SUCCESS) {
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    void *map;
-    if (vkBindBufferMemory(q36_vk.device, staging, staging_mem, 0) != VK_SUCCESS ||
-        vkMapMemory(q36_vk.device, staging_mem, 0, req.size, 0, &map) != VK_SUCCESS)
-    {
-        vkFreeMemory(q36_vk.device, staging_mem, NULL);
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    memcpy(map, src, (size_t)bytes);
-    vkUnmapMemory(q36_vk.device, staging_mem);
-
-    VkCommandBufferAllocateInfo cai = {
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-        .commandPool = q36_vk.command_pool,
-        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-        .commandBufferCount = 1,
-    };
-    VkCommandBuffer cb;
-    if (vkAllocateCommandBuffers(q36_vk.device, &cai, &cb) != VK_SUCCESS) {
-        vkFreeMemory(q36_vk.device, staging_mem, NULL);
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    VkCommandBufferBeginInfo bi = {
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
-    };
-    VkFence fence;
-    VkFenceCreateInfo fci = { .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
-    if (vkBeginCommandBuffer(cb, &bi) != VK_SUCCESS ||
-        vkCreateFence(q36_vk.device, &fci, NULL, &fence) != VK_SUCCESS)
-    {
-        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
-        vkFreeMemory(q36_vk.device, staging_mem, NULL);
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    VkBufferCopy region = { .srcOffset = 0, .dstOffset = dst_offset, .size = bytes };
-    vkCmdCopyBuffer(cb, staging, tensor->buffer, 1, &region);
-    if (vkEndCommandBuffer(cb) != VK_SUCCESS) {
-        vkDestroyFence(q36_vk.device, fence, NULL);
-        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
-        vkFreeMemory(q36_vk.device, staging_mem, NULL);
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    VkSubmitInfo si = {
-        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-        .commandBufferCount = 1,
-        .pCommandBuffers = &cb,
-    };
-    VkResult rc = vkQueueSubmit(q36_vk.queue, 1, &si, fence);
-    if (rc != VK_SUCCESS) {
-        vkDestroyFence(q36_vk.device, fence, NULL);
-        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
-        vkFreeMemory(q36_vk.device, staging_mem, NULL);
-        vkDestroyBuffer(q36_vk.device, staging, NULL);
-        return 0;
-    }
-    vkWaitForFences(q36_vk.device, 1, &fence, VK_TRUE, UINT64_MAX);
-    vkDestroyFence(q36_vk.device, fence, NULL);
-    vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
-    vkFreeMemory(q36_vk.device, staging_mem, NULL);
-    vkDestroyBuffer(q36_vk.device, staging, NULL);
-    return 1;
 }
 
 static q36_gpu_tensor *q36_vk_tensor_alloc_kind_unlocked(uint64_t bytes, bool device_pref) {
@@ -1570,10 +1489,42 @@ static q36_gpu_tensor *q36_vk_tensor_alloc_kind_unlocked(uint64_t bytes, bool de
     return tensor;
 }
 
+static void q36_vk_tensor_free_unlocked(q36_gpu_tensor *tensor);
+
+static q36_gpu_tensor *q36_vk_tensor_alloc_scratch_unlocked(uint64_t bytes) {
+    const uint64_t alloc_bytes = bytes ? q36_round_up_u64(bytes, 4) : 4;
+    for (uint32_t i = 0; i < q36_vk_private_pool_n; i++) {
+        q36_gpu_tensor *tensor = q36_vk_private_pool[i];
+        if (tensor->alloc_bytes != alloc_bytes) continue;
+        q36_vk_private_pool[i] = q36_vk_private_pool[--q36_vk_private_pool_n];
+        tensor->bytes = bytes;
+        tensor->gpu_written = false;
+        tensor->last_use_seq = 0;
+        q36_gpu_live_bytes += bytes;
+        if (q36_gpu_live_bytes > q36_gpu_peak_bytes) q36_gpu_peak_bytes = q36_gpu_live_bytes;
+        return tensor;
+    }
+    if (q36_vk_private_bytes <= Q36_VK_PRIVATE_LIMIT &&
+        alloc_bytes <= Q36_VK_PRIVATE_LIMIT - q36_vk_private_bytes) {
+        q36_gpu_tensor *tensor = q36_vk_tensor_alloc_dl_unlocked(bytes);
+        if (tensor && tensor->private_charge <=
+                      Q36_VK_PRIVATE_LIMIT - q36_vk_private_bytes) {
+            tensor->private_scratch = true;
+            q36_vk_private_bytes += tensor->private_charge;
+            if (q36_vk_private_bytes > q36_vk_private_peak)
+                q36_vk_private_peak = q36_vk_private_bytes;
+            return tensor;
+        }
+        q36_vk_tensor_free_unlocked(tensor);
+    }
+    return q36_vk_tensor_alloc_kind_unlocked(bytes, false);
+}
+
 static void q36_vk_tensor_free_unlocked(q36_gpu_tensor *tensor) {
     if (!tensor) return;
     if (!tensor->owner) {
         q36_gpu_live_bytes -= tensor->bytes;
+        if (tensor->private_scratch) q36_vk_private_bytes -= tensor->private_charge;
         if (tensor->data) vkUnmapMemory(q36_vk.device, tensor->memory);
         if (tensor->memory) vkFreeMemory(q36_vk.device, tensor->memory, NULL);
         if (tensor->buffer) vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
@@ -1586,8 +1537,21 @@ static void q36_vk_tensor_free_unlocked(q36_gpu_tensor *tensor) {
  * every slot with chunk-sized scratch and decode-sized buffers can never
  * enter, turning each decode step into fresh vkAllocateMemory calls. */
 static uint32_t q36_vk_pool_rr;
+static uint32_t q36_vk_private_pool_rr;
 static void q36_vk_tensor_retire_unlocked(q36_gpu_tensor *tensor) {
-    if (!tensor->owner && !tensor->device_local && tensor->data &&
+    if (!tensor->owner && tensor->private_scratch) {
+        q36_gpu_live_bytes -= tensor->bytes;
+        tensor->bytes = 0;
+        if (q36_vk_private_pool_n < Q36_VK_PRIVATE_POOL_CAP) {
+            q36_vk_private_pool[q36_vk_private_pool_n++] = tensor;
+        } else {
+            q36_vk_private_pool[q36_vk_private_pool_rr]->bytes = 0;
+            q36_vk_tensor_free_unlocked(q36_vk_private_pool[q36_vk_private_pool_rr]);
+            q36_vk_private_pool[q36_vk_private_pool_rr] = tensor;
+            q36_vk_private_pool_rr =
+                (q36_vk_private_pool_rr + 1u) % Q36_VK_PRIVATE_POOL_CAP;
+        }
+    } else if (!tensor->owner && !tensor->device_local && tensor->data &&
         tensor->alloc_bytes <= Q36_VK_POOL_MAX_BYTES) {
         q36_gpu_live_bytes -= tensor->bytes;
         if (q36_vk_pool_n < Q36_VK_POOL_CAP) {
@@ -1955,18 +1919,12 @@ static q36_gpu_tensor *q36_vk_weight_get_unlocked(const void *source, uint64_t b
         }
     }
 
-    q36_gpu_tensor *tensor = q36_vk_tensor_alloc_dl_only_unlocked(bytes);
-    if (!tensor) tensor = q36_vk_arena_alloc_unlocked(bytes);
+    q36_gpu_tensor *tensor = q36_vk_arena_alloc_unlocked(bytes);
     if (!tensor) return NULL;
     {
         uint64_t offset = 0;
         q36_gpu_tensor *root = q36_gpu_tensor_root(tensor, &offset);
-        if (!root->data) {
-            if (!q36_vk_write_tensor_staged(root, offset, source, bytes)) {
-                q36_vk_tensor_free_unlocked(tensor);
-                return NULL;
-            }
-        } else if (q36_vk_weight_copy_parallel) {
+        if (q36_vk_weight_copy_parallel) {
             q36_vk_weight_copy_ctx c = { root->data + offset, source, bytes };
             q36_gpu_parallel_for_rows((bytes + ((1u << 20) - 1)) >> 20, 8, q36_vk_weight_copy_rows, &c);
         } else {
@@ -2899,6 +2857,8 @@ void q36_gpu_cleanup(void) {
     q36_vk_hazard_reset();
     while (q36_vk_retired_n) q36_vk_tensor_free_unlocked(q36_vk_retired[--q36_vk_retired_n]);
     while (q36_vk_pool_n) q36_vk_tensor_free_unlocked(q36_vk_pool[--q36_vk_pool_n]);
+    while (q36_vk_private_pool_n)
+        q36_vk_tensor_free_unlocked(q36_vk_private_pool[--q36_vk_private_pool_n]);
     q36_vk_weight_cache_free_unlocked();
     q36_vk_tensor_free_unlocked(q36_vk.iq_tables);
     q36_vk.iq_tables = NULL;
@@ -2989,6 +2949,8 @@ void q36_gpu_cleanup(void) {
     q36_gpu_model_fd = -1;
     q36_gpu_quality = false;
     q36_gpu_commands_open = false;
+    q36_vk_private_bytes = 0;
+    q36_vk_private_peak = 0;
     q36_vk_moe_bank_cache = true;
     pthread_mutex_unlock(&q36_vk_mu);
     q36_vk_host_threads_shutdown();
@@ -3012,6 +2974,14 @@ q36_gpu_tensor *q36_gpu_tensor_alloc(uint64_t bytes) {
         break;
     }
     if (!tensor) tensor = q36_vk_tensor_alloc_kind_unlocked(bytes, false);
+    pthread_mutex_unlock(&q36_vk_mu);
+    return tensor;
+}
+
+q36_gpu_tensor *q36_gpu_tensor_alloc_scratch(uint64_t bytes) {
+    if (!q36_gpu_init()) return NULL;
+    pthread_mutex_lock(&q36_vk_mu);
+    q36_gpu_tensor *tensor = q36_vk_tensor_alloc_scratch_unlocked(bytes);
     pthread_mutex_unlock(&q36_vk_mu);
     return tensor;
 }
@@ -3422,11 +3392,17 @@ int q36_gpu_stream_expert_cache_bias_experts(const q36_gpu_stream_expert_table *
 
 void q36_gpu_print_memory_report(const char *label) {
     fprintf(stderr,
-            "q36: Vulkan memory%s%s live=%" PRIu64 " peak=%" PRIu64 " fd=%d quality=%s ssd_streaming=%s cache=%u/%u requested=%u allocation_failures=%u lookup=%s lookup_steps=%" PRIu64 " hits=%" PRIu64 " misses=%" PRIu64 " loads=%" PRIu64 " evictions=%" PRIu64 " device=%s api=%u.%u.%u\n",
+            "q36: Vulkan memory%s%s live=%" PRIu64 " peak=%" PRIu64
+            " scratch_private=%" PRIu64 " scratch_private_peak=%" PRIu64
+            " scratch_private_limit=%" PRIu64
+            " fd=%d quality=%s ssd_streaming=%s cache=%u/%u requested=%u allocation_failures=%u lookup=%s lookup_steps=%" PRIu64 " hits=%" PRIu64 " misses=%" PRIu64 " loads=%" PRIu64 " evictions=%" PRIu64 " device=%s api=%u.%u.%u\n",
             label ? " " : "",
             label ? label : "",
             q36_gpu_live_bytes,
             q36_gpu_peak_bytes,
+            q36_vk_private_bytes,
+            q36_vk_private_peak,
+            (uint64_t)Q36_VK_PRIVATE_LIMIT,
             q36_gpu_model_fd,
             q36_gpu_quality ? "high" : "fast",
             q36_vk_stream.enabled ? "on" : "off",
@@ -4242,8 +4218,7 @@ static q36_gpu_tensor *q36_vk_packed_weight_get_unlocked(const unsigned char *so
     const uint64_t packed_bytes = (uint64_t)row_tiles * blocks * pack_block_bytes;
     if (pack_block_bytes == 0 || blocks == 0 || row_tiles == 0) return NULL;
 
-    q36_gpu_tensor *tensor = q36_vk_tensor_alloc_dl_only_unlocked(packed_bytes);
-    if (!tensor) tensor = q36_vk_arena_alloc_unlocked(packed_bytes);
+    q36_gpu_tensor *tensor = q36_vk_arena_alloc_unlocked(packed_bytes);
     if (!tensor) return NULL;
     uint64_t offset = 0;
     q36_gpu_tensor *root = q36_gpu_tensor_root(tensor, &offset);
@@ -4252,23 +4227,7 @@ static q36_gpu_tensor *q36_vk_packed_weight_get_unlocked(const unsigned char *so
         return NULL;
     }
 
-    if (!root->data) {
-        unsigned char *tmp = malloc((size_t)packed_bytes);
-        if (!tmp) {
-            q36_vk_tensor_free_unlocked(tensor);
-            return NULL;
-        }
-        if (type == Q36_VK_TENSOR_Q5_K)
-            q36_vk_pack_q5_kx8_matrix(tmp, source, out_dim, blocks, (uint32_t)src_row_bytes);
-        else
-            q36_vk_pack_q6_kx8_matrix(tmp, source, out_dim, blocks, (uint32_t)src_row_bytes);
-        int ok = q36_vk_write_tensor_staged(root, offset, tmp, packed_bytes);
-        free(tmp);
-        if (!ok) {
-            q36_vk_tensor_free_unlocked(tensor);
-            return NULL;
-        }
-    } else if (type == Q36_VK_TENSOR_Q5_K) {
+    if (type == Q36_VK_TENSOR_Q5_K) {
         q36_vk_pack_q5_kx8_matrix(root->data + offset, source, out_dim, blocks, (uint32_t)src_row_bytes);
     } else if (type == Q36_VK_TENSOR_Q6_K) {
         q36_vk_pack_q6_kx8_matrix(root->data + offset, source, out_dim, blocks, (uint32_t)src_row_bytes);
@@ -4795,25 +4754,9 @@ int q36_gpu_add_rms_norm_tensor(q36_gpu_tensor *out_norm,
  * moe_matvec kernel.  Layout must match the TAB_* offsets in the shader. */
 static q36_gpu_tensor *q36_vk_iq_tables_unlocked(void) {
     if (q36_vk.iq_tables) return q36_vk.iq_tables;
-    q36_gpu_tensor *t = q36_vk_tensor_alloc_dl_only_unlocked(Q36_VK_TAB_TOTAL_BYTES);
-    if (!t) {
-        t = q36_vk_tensor_alloc_kind_unlocked(Q36_VK_TAB_TOTAL_BYTES, true);
-        if (!t) return NULL;
-        q36_vk_pack_iq_tables(t->data);
-    } else {
-        unsigned char *tmp = malloc(Q36_VK_TAB_TOTAL_BYTES);
-        if (!tmp) {
-            q36_vk_tensor_free_unlocked(t);
-            return NULL;
-        }
-        q36_vk_pack_iq_tables(tmp);
-        if (!q36_vk_write_tensor_staged(t, 0, tmp, Q36_VK_TAB_TOTAL_BYTES)) {
-            free(tmp);
-            q36_vk_tensor_free_unlocked(t);
-            return NULL;
-        }
-        free(tmp);
-    }
+    q36_gpu_tensor *t = q36_vk_tensor_alloc_kind_unlocked(Q36_VK_TAB_TOTAL_BYTES, true);
+    if (!t) return NULL;
+    q36_vk_pack_iq_tables(t->data);
     q36_vk.iq_tables = t;
     return t;
 }
@@ -5845,7 +5788,7 @@ int q36_gpu_attn_decode_tensor(q36_gpu_tensor *out,
             q36_gpu_tensor *part = q36_vk.attn_part;
             if (!part || q36_vk.attn_part_bytes < part_bytes) {
                 q36_vk_tensor_release_unlocked(q36_vk.attn_part);
-                part = q36_vk_tensor_alloc_kind_unlocked(part_bytes, true);
+                part = q36_vk_tensor_alloc_scratch_unlocked(part_bytes);
                 q36_vk.attn_part = part;
                 q36_vk.attn_part_bytes = part ? part_bytes : 0;
             }
@@ -5916,7 +5859,7 @@ int q36_gpu_attn_decode_tensor(q36_gpu_tensor *out,
             q36_gpu_tensor *part = q36_vk.attn_part;
             if (!part || q36_vk.attn_part_bytes < part_bytes) {
                 q36_vk_tensor_release_unlocked(q36_vk.attn_part);
-                part = q36_vk_tensor_alloc_kind_unlocked(part_bytes, true);
+                part = q36_vk_tensor_alloc_scratch_unlocked(part_bytes);
                 q36_vk.attn_part = part;
                 q36_vk.attn_part_bytes = part ? part_bytes : 0;
             }
@@ -5990,7 +5933,9 @@ int q36_gpu_attn_decode_tensor(q36_gpu_tensor *out,
         pthread_mutex_unlock(&q36_vk_mu);
     }
     if (!ok) return 0;
-    aux = q36_gpu_tensor_alloc(aux_floats * n_tok * sizeof(float));
+    aux = q36_gpu_quality ?
+        q36_gpu_tensor_alloc(aux_floats * n_tok * sizeof(float)) :
+        q36_gpu_tensor_alloc_scratch(aux_floats * n_tok * sizeof(float));
     if (!aux) return 0;
 
     if (!q36_gpu_quality && q36_vk_use_gpu_attn_post()) {
@@ -6267,7 +6212,7 @@ static q36_gpu_tensor *q36_vk_quantize_q8_k_alloc_tensor(const q36_gpu_tensor *x
         !q36_u64_mul_ok(q8_count, sizeof(q36_vk_block_q8_K), &q8_bytes)) {
         return NULL;
     }
-    q8 = q36_gpu_tensor_alloc(q8_bytes);
+    q8 = q36_gpu_tensor_alloc_scratch(q8_bytes);
     if (!q8) return NULL;
     if (!q36_gpu_quantize_q8_k_tensor(q8, x, in_dim, n_tok)) {
         q36_gpu_tensor_free(q8);
@@ -6302,7 +6247,7 @@ static q36_gpu_tensor *q36_vk_moe_tiles_gpu(const q36_gpu_tensor *selected, uint
     tile_bound = q36_vk_moe_tile_bound(n_slot, n_expert, pair_tile);
     tile_words = 1u + pair_tile;
     if (!q36_u64_mul_ok(tile_bound, tile_words, &words)) return NULL;
-    q36_gpu_tensor *tiles = q36_gpu_tensor_alloc(words * sizeof(uint32_t));
+    q36_gpu_tensor *tiles = q36_gpu_tensor_alloc_scratch(words * sizeof(uint32_t));
     q36_gpu_tensor *map = NULL;
     if (!tiles) return NULL;
     if (slot_map) {
@@ -6858,15 +6803,15 @@ int q36_gpu_moe_ffn_q8_tensor(q36_gpu_tensor *out,
         }
     }
 
-    mid8 = q36_gpu_tensor_alloc(mid_bytes * n_tok);
-    down8 = q36_gpu_tensor_alloc(down_bytes * n_tok);
+    mid8 = q36_gpu_tensor_alloc_scratch(mid_bytes * n_tok);
+    down8 = q36_gpu_tensor_alloc_scratch(down_bytes * n_tok);
     ok = qx && mid8 && down8 &&
           q36_vk_moe_gate_up_iq2_swiglu(mid8, model_map, model_size, gate, up,
                                          selected, qx, stream_slots, resident_bank,
                                          n_used, n_tok, in_dim, mid_dim, n_expert);
     if (!ok && mid8 && down8) {
-        gate8 = q36_gpu_tensor_alloc(mid_bytes * n_tok);
-        up8 = q36_gpu_tensor_alloc(mid_bytes * n_tok);
+        gate8 = q36_gpu_tensor_alloc_scratch(mid_bytes * n_tok);
+        up8 = q36_gpu_tensor_alloc_scratch(mid_bytes * n_tok);
         ok = gate8 && up8 &&
              q36_vk_moe_matvec(gate8, model_map, model_size, gate, qx, false, false,
                                 stream_slots ? Q36_VK_STREAM_PART_GATE : Q36_VK_STREAM_PART_NONE,
@@ -7053,8 +6998,8 @@ int q36_gpu_moe_ffn_f32_tensor(q36_gpu_tensor *out,
         if (!tiles) goto done;
         tile_count = q36_vk_moe_tile_bound((uint32_t)n_slot, n_expert, pair_tile);
     }
-    mid8 = q36_gpu_tensor_alloc(n_slot * mid_dim * sizeof(float));
-    if (!down_sum_decode) down8 = q36_gpu_tensor_alloc(n_slot * out_dim * sizeof(float));
+    mid8 = q36_gpu_tensor_alloc_scratch(n_slot * mid_dim * sizeof(float));
+    if (!down_sum_decode) down8 = q36_gpu_tensor_alloc_scratch(n_slot * out_dim * sizeof(float));
     if (!mid8 || (!down_sum_decode && !down8)) goto done;
 
     uint32_t wave = 0;

--- a/q36_vulkan.c
+++ b/q36_vulkan.c
@@ -1342,6 +1342,159 @@ static int q36_vk_kernel_init(q36_vk_kernel *k) {
     return 1;
 }
 
+/* Allocate from DEVICE_LOCAL-only memory (the VRAM carve-out / BAR
+ * aperture, types 0/1/7 in heap 1 on the BC-250).  The tensor is NOT
+ * host-mapped; writes must go through q36_vk_write_tensor_staged().
+ * Returns NULL on OOM or if no DEVICE_LOCAL-only type supports the
+ * buffer's required memory type bits. */
+static q36_gpu_tensor *q36_vk_tensor_alloc_dl_only_unlocked(uint64_t bytes) {
+    q36_gpu_tensor *tensor = calloc(1, sizeof(*tensor));
+    if (!tensor) return NULL;
+    tensor->bytes = bytes;
+    tensor->alloc_bytes = bytes ? q36_round_up_u64(bytes, 4) : 4;
+
+    VkBufferCreateInfo bci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = tensor->alloc_bytes,
+        .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+    if (vkCreateBuffer(q36_vk.device, &bci, NULL, &tensor->buffer) != VK_SUCCESS) {
+        free(tensor);
+        return NULL;
+    }
+
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(q36_vk.device, tensor->buffer, &req);
+    uint32_t mt = q36_vk_find_memory_type(req.memoryTypeBits,
+                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (mt == UINT32_MAX) {
+        vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
+        free(tensor);
+        return NULL;
+    }
+    VkMemoryAllocateInfo mai = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = req.size,
+        .memoryTypeIndex = mt,
+    };
+    if (vkAllocateMemory(q36_vk.device, &mai, NULL, &tensor->memory) != VK_SUCCESS) {
+        vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
+        free(tensor);
+        return NULL;
+    }
+    if (vkBindBufferMemory(q36_vk.device, tensor->buffer, tensor->memory, 0) != VK_SUCCESS) {
+        vkFreeMemory(q36_vk.device, tensor->memory, NULL);
+        vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
+        free(tensor);
+        return NULL;
+    }
+    tensor->device_local = true;
+    return tensor;
+}
+
+/* Staging copy helper for DEVICE_LOCAL-only tensors.  Creates a temporary
+ * host-visible staging buffer, copies |bytes| from |src| into it, records a
+ * vkCmdCopyBuffer from staging to the root buffer at |dst_offset|, submits
+ * on its own command buffer (independent of the main batch), and waits for
+ * completion.  Only suitable for one-shot uploads at init time. */
+static int q36_vk_write_tensor_staged(q36_gpu_tensor *tensor, uint64_t dst_offset,
+                                       const void *src, uint64_t bytes) {
+    VkBufferCreateInfo bci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes,
+        .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+    VkBuffer staging;
+    if (vkCreateBuffer(q36_vk.device, &bci, NULL, &staging) != VK_SUCCESS) return 0;
+
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(q36_vk.device, staging, &req);
+    uint32_t mt = q36_vk_find_memory_type(req.memoryTypeBits,
+                                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (mt == UINT32_MAX) {
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    VkDeviceMemory staging_mem;
+    VkMemoryAllocateInfo mai = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = req.size,
+        .memoryTypeIndex = mt,
+    };
+    if (vkAllocateMemory(q36_vk.device, &mai, NULL, &staging_mem) != VK_SUCCESS) {
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    void *map;
+    if (vkBindBufferMemory(q36_vk.device, staging, staging_mem, 0) != VK_SUCCESS ||
+        vkMapMemory(q36_vk.device, staging_mem, 0, req.size, 0, &map) != VK_SUCCESS)
+    {
+        vkFreeMemory(q36_vk.device, staging_mem, NULL);
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    memcpy(map, src, (size_t)bytes);
+    vkUnmapMemory(q36_vk.device, staging_mem);
+
+    VkCommandBufferAllocateInfo cai = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = q36_vk.command_pool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = 1,
+    };
+    VkCommandBuffer cb;
+    if (vkAllocateCommandBuffers(q36_vk.device, &cai, &cb) != VK_SUCCESS) {
+        vkFreeMemory(q36_vk.device, staging_mem, NULL);
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    VkCommandBufferBeginInfo bi = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+    };
+    VkFence fence;
+    VkFenceCreateInfo fci = { .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+    if (vkBeginCommandBuffer(cb, &bi) != VK_SUCCESS ||
+        vkCreateFence(q36_vk.device, &fci, NULL, &fence) != VK_SUCCESS)
+    {
+        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
+        vkFreeMemory(q36_vk.device, staging_mem, NULL);
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    VkBufferCopy region = { .srcOffset = 0, .dstOffset = dst_offset, .size = bytes };
+    vkCmdCopyBuffer(cb, staging, tensor->buffer, 1, &region);
+    if (vkEndCommandBuffer(cb) != VK_SUCCESS) {
+        vkDestroyFence(q36_vk.device, fence, NULL);
+        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
+        vkFreeMemory(q36_vk.device, staging_mem, NULL);
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    VkSubmitInfo si = {
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &cb,
+    };
+    VkResult rc = vkQueueSubmit(q36_vk.queue, 1, &si, fence);
+    if (rc != VK_SUCCESS) {
+        vkDestroyFence(q36_vk.device, fence, NULL);
+        vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
+        vkFreeMemory(q36_vk.device, staging_mem, NULL);
+        vkDestroyBuffer(q36_vk.device, staging, NULL);
+        return 0;
+    }
+    vkWaitForFences(q36_vk.device, 1, &fence, VK_TRUE, UINT64_MAX);
+    vkDestroyFence(q36_vk.device, fence, NULL);
+    vkFreeCommandBuffers(q36_vk.device, q36_vk.command_pool, 1, &cb);
+    vkFreeMemory(q36_vk.device, staging_mem, NULL);
+    vkDestroyBuffer(q36_vk.device, staging, NULL);
+    return 1;
+}
+
 static q36_gpu_tensor *q36_vk_tensor_alloc_kind_unlocked(uint64_t bytes, bool device_pref) {
     q36_gpu_tensor *tensor = calloc(1, sizeof(*tensor));
     if (!tensor) return NULL;
@@ -1421,7 +1574,7 @@ static void q36_vk_tensor_free_unlocked(q36_gpu_tensor *tensor) {
     if (!tensor) return;
     if (!tensor->owner) {
         q36_gpu_live_bytes -= tensor->bytes;
-        if (tensor->memory) vkUnmapMemory(q36_vk.device, tensor->memory);
+        if (tensor->data) vkUnmapMemory(q36_vk.device, tensor->memory);
         if (tensor->memory) vkFreeMemory(q36_vk.device, tensor->memory, NULL);
         if (tensor->buffer) vkDestroyBuffer(q36_vk.device, tensor->buffer, NULL);
     }
@@ -1802,12 +1955,18 @@ static q36_gpu_tensor *q36_vk_weight_get_unlocked(const void *source, uint64_t b
         }
     }
 
-    q36_gpu_tensor *tensor = q36_vk_arena_alloc_unlocked(bytes);
+    q36_gpu_tensor *tensor = q36_vk_tensor_alloc_dl_only_unlocked(bytes);
+    if (!tensor) tensor = q36_vk_arena_alloc_unlocked(bytes);
     if (!tensor) return NULL;
     {
         uint64_t offset = 0;
         q36_gpu_tensor *root = q36_gpu_tensor_root(tensor, &offset);
-        if (q36_vk_weight_copy_parallel) {
+        if (!root->data) {
+            if (!q36_vk_write_tensor_staged(root, offset, source, bytes)) {
+                q36_vk_tensor_free_unlocked(tensor);
+                return NULL;
+            }
+        } else if (q36_vk_weight_copy_parallel) {
             q36_vk_weight_copy_ctx c = { root->data + offset, source, bytes };
             q36_gpu_parallel_for_rows((bytes + ((1u << 20) - 1)) >> 20, 8, q36_vk_weight_copy_rows, &c);
         } else {
@@ -4083,7 +4242,8 @@ static q36_gpu_tensor *q36_vk_packed_weight_get_unlocked(const unsigned char *so
     const uint64_t packed_bytes = (uint64_t)row_tiles * blocks * pack_block_bytes;
     if (pack_block_bytes == 0 || blocks == 0 || row_tiles == 0) return NULL;
 
-    q36_gpu_tensor *tensor = q36_vk_arena_alloc_unlocked(packed_bytes);
+    q36_gpu_tensor *tensor = q36_vk_tensor_alloc_dl_only_unlocked(packed_bytes);
+    if (!tensor) tensor = q36_vk_arena_alloc_unlocked(packed_bytes);
     if (!tensor) return NULL;
     uint64_t offset = 0;
     q36_gpu_tensor *root = q36_gpu_tensor_root(tensor, &offset);
@@ -4092,7 +4252,23 @@ static q36_gpu_tensor *q36_vk_packed_weight_get_unlocked(const unsigned char *so
         return NULL;
     }
 
-    if (type == Q36_VK_TENSOR_Q5_K) {
+    if (!root->data) {
+        unsigned char *tmp = malloc((size_t)packed_bytes);
+        if (!tmp) {
+            q36_vk_tensor_free_unlocked(tensor);
+            return NULL;
+        }
+        if (type == Q36_VK_TENSOR_Q5_K)
+            q36_vk_pack_q5_kx8_matrix(tmp, source, out_dim, blocks, (uint32_t)src_row_bytes);
+        else
+            q36_vk_pack_q6_kx8_matrix(tmp, source, out_dim, blocks, (uint32_t)src_row_bytes);
+        int ok = q36_vk_write_tensor_staged(root, offset, tmp, packed_bytes);
+        free(tmp);
+        if (!ok) {
+            q36_vk_tensor_free_unlocked(tensor);
+            return NULL;
+        }
+    } else if (type == Q36_VK_TENSOR_Q5_K) {
         q36_vk_pack_q5_kx8_matrix(root->data + offset, source, out_dim, blocks, (uint32_t)src_row_bytes);
     } else if (type == Q36_VK_TENSOR_Q6_K) {
         q36_vk_pack_q6_kx8_matrix(root->data + offset, source, out_dim, blocks, (uint32_t)src_row_bytes);
@@ -4619,9 +4795,25 @@ int q36_gpu_add_rms_norm_tensor(q36_gpu_tensor *out_norm,
  * moe_matvec kernel.  Layout must match the TAB_* offsets in the shader. */
 static q36_gpu_tensor *q36_vk_iq_tables_unlocked(void) {
     if (q36_vk.iq_tables) return q36_vk.iq_tables;
-    q36_gpu_tensor *t = q36_vk_tensor_alloc_kind_unlocked(Q36_VK_TAB_TOTAL_BYTES, true);
-    if (!t) return NULL;
-    q36_vk_pack_iq_tables(t->data);
+    q36_gpu_tensor *t = q36_vk_tensor_alloc_dl_only_unlocked(Q36_VK_TAB_TOTAL_BYTES);
+    if (!t) {
+        t = q36_vk_tensor_alloc_kind_unlocked(Q36_VK_TAB_TOTAL_BYTES, true);
+        if (!t) return NULL;
+        q36_vk_pack_iq_tables(t->data);
+    } else {
+        unsigned char *tmp = malloc(Q36_VK_TAB_TOTAL_BYTES);
+        if (!tmp) {
+            q36_vk_tensor_free_unlocked(t);
+            return NULL;
+        }
+        q36_vk_pack_iq_tables(tmp);
+        if (!q36_vk_write_tensor_staged(t, 0, tmp, Q36_VK_TAB_TOTAL_BYTES)) {
+            free(tmp);
+            q36_vk_tensor_free_unlocked(t);
+            return NULL;
+        }
+        free(tmp);
+    }
     q36_vk.iq_tables = t;
     return t;
 }

--- a/tests/q36_test.c
+++ b/tests/q36_test.c
@@ -3753,12 +3753,21 @@ static void test_long_security_continuation(void) {
     TEST_ASSERT(prompt_text != NULL);
     if (!prompt_text) return;
 
-    q36_engine *engine = test_get_engine(false);
+    q36_backend backend = test_default_backend();
+    q36_engine_options opt = {
+        .model_path = test_model_path(),
+        .backend = backend,
+        .cache_type_k = q36_default_kv_cache_type_k(backend, false),
+        .cache_type_v = q36_default_kv_cache_type_v(backend, false),
+    };
+    q36_engine *engine = NULL;
+    TEST_ASSERT(q36_engine_open(&engine, &opt) == 0);
     if (!engine) {
         free(prompt_text);
         return;
     }
     if (!test_require_session_backend("long-context", engine, 100000)) {
+        q36_engine_close(engine);
         free(prompt_text);
         return;
     }
@@ -3771,6 +3780,7 @@ static void test_long_security_continuation(void) {
     TEST_ASSERT(q36_session_create(&session, engine, 100000) == 0);
     if (!session) {
         q36_tokens_free(&prompt);
+        q36_engine_close(engine);
         free(prompt_text);
         return;
     }
@@ -3800,16 +3810,19 @@ static void test_long_security_continuation(void) {
     }
 
     const char *text = out.ptr ? out.ptr : "";
+    const char *answer = strstr(text, "</think>");
     TEST_ASSERT(decode_ok);
     TEST_ASSERT(generated > 0);
-    TEST_ASSERT(strstr(text, "</think>") != NULL);
+    TEST_ASSERT(answer != NULL);
     TEST_ASSERT(test_count_substr(text, "</think>") == 1);
-    TEST_ASSERT(test_count_substr(text, "The most critical security issue") == 1);
-    TEST_ASSERT(strstr(text, "arbitrary file") != NULL);
+    answer = answer ? answer + strlen("</think>") : text;
+    TEST_ASSERT(test_count_substr(answer, "The most critical security issue") == 1);
+    TEST_ASSERT(strstr(answer, "arbitrary file") != NULL);
 
     buf_free(&out);
     q36_session_free(session);
     q36_tokens_free(&prompt);
+    q36_engine_close(engine);
     free(prompt_text);
 }
 


### PR DESCRIPTION
Uses the BC-250 non-host-visible device-local heap discovered by @Jakdaw.

The implementation evolved from staged weights to output-only GPU scratch after benchmarking showed that scratch avoids staging copies and gives the useful performance gain.

Final design:

- lazy device-private scratch allocation with a 512 MiB ceiling
- exact-size reuse of retired transient buffers
- automatic fallback to host-visible memory when the private heap is unavailable or full
- private allocation accounting in the Vulkan memory report
- unchanged quality-mode persistent allocations

Validated on resident Vulkan, SSD streaming, compressed 100K KV, CPU/Vulkan parity, Vulkan kernels, MTP, server, agent, and eval paths.

The device-local heap discovery and original prototype are credited to @Jakdaw.
